### PR TITLE
Breaking changes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,13 @@ export interface Builder {
 
     asLibrary(type: "amd"|"umd"|"commonjs", name: string): this;
 
-    to(target: string, path: string, outFileName: string, debugOutFileName?: string): Configuration;
+    compile(
+        target: string,
+        sourcePath: string,
+        outPath: string,
+        outFileName: string,
+        debugOutFileName?: string,
+    ): Configuration;
 }
 
-export function from(path: string, ...roots?: string[]): Builder;
+export function newConfigBuilder(): Builder;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,28 +1,29 @@
 import type {WebpackPluginInstance, Configuration, RuleSetRule} from "webpack";
 
 export interface Builder {
-    withDefine(symbol: string, value: string, debugValue?: string);
     withExtension(...extensions: string[]): this;
-    withPlugin(plugin: WebpackPluginInstance): this;
-    withRule(rule: RuleSetRule): this;
-    /** @deprecated since version 0.2.0 */
-    withFont(outputPath: string): this;
+    withPlugin<C>(type: {new(cfg: C): WebpackPluginInstance}, config: C, debugConfig: C): this;
     withAssets(test: RegExp): this;
+    withDefine(symbol: string, value: string, debugValue?: string): this;
     withNoParse(path: Configuration["module"]["noParse"]): this;
-    withReact(): this;
+
     withCss(outName: string, debugOutName?: string): this;
     withHtml(templatePath: string, outName: string): this;
+
+    withReact(): this;
     withExternals(externals: Configuration["externals"]): this;
     withNativeModules(): this;
     withFiles(options: string | unknown[]): this;
+
     withLicenseHint(name: string, version: string, license: string): this;
-    withUnacceptableLicense(...name: string[]): this;
+    withoutLicense(...name: string[]): this;
     withAttributionsPath(path): this;
+
     withDevServer(port: number, allowedHosts?: string[]): this;
-    withDefine(symbol: string, value: string, debugValue: string): this;
+
     asLibrary(type: "amd"|"umd"|"commonjs", name: string): this;
-    to(target: string, path: string, outFileName: string, debugOutFileName?: string): this;
-    build(): Configuration;
+
+    to(target: string, path: string, outFileName: string, debugOutFileName?: string): Configuration;
 }
 
 export function from(path: string, ...roots?: string[]): Builder;

--- a/index.js
+++ b/index.js
@@ -112,6 +112,8 @@ function buildConfig(env, argv) {
 }
 
 const methods = {
+    directives: Object.freeze([]),
+
     withExtension: function withExtension(...extensions) {
         return extend(this, function () {
             this.resolve.extensions.push(...extensions);
@@ -120,7 +122,7 @@ const methods = {
 
     withPlugin: function withPlugin(type, config, debugConfig) {
         return extend(this, function ({mode}) {
-            const cfg = !debufConfig || mode == ProdMode ? config : debugConfig;
+            const cfg = !debugConfig || mode == ProdMode ? config : debugConfig;
             const plugin = new type(cfg);
             this.plugins.push(plugin);
         });
@@ -257,14 +259,16 @@ const methods = {
         });
     },
 
-    to: function to(target, path, outFileName, debugOutFileName) {
+    compile: function compile(target, entrypoint, outPath, outFileName, debugOutFileName) {
         this.directives.unshift(function ({mode}) {
             this.target = target;
 
-            this.output.path = path;
+            this.output.path = outPath;
             this.output.filename = !debugOutFileName || mode === ProdMode
                 ? outFileName
                 : debugOutFileName;
+
+            this.entry = entrypoint;
         });
 
         return buildConfig.bind(this);
@@ -277,15 +281,6 @@ function extend(that, f) {
     return result;
 }
 
-module.exports.from = function from(entrypoint, ...roots) {
-    var result = Object.create(methods);
-
-    result.directives = [
-        function () {
-            this.entry = entrypoint;
-            roots && (this.resolve.roots = roots);
-        },
-    ];
-
-    return result;
-}
+module.exports.newConfigBuilder = function newConfigBuilder() {
+    return Object.create(methods);
+};

--- a/index.js
+++ b/index.js
@@ -244,7 +244,6 @@ const methods = {
     withDevServer: function withDevServer(port, allowedHosts) {
         return extend(this, function() {
             this.devServer = {
-                contentBase: this.output.path,
                 compress: true,
                 port,
                 allowedHosts,

--- a/index.js
+++ b/index.js
@@ -137,14 +137,8 @@ const methods = {
     withAssets: function withAssets(test) {
         return this.withRule({
             test,
-            use: [
-                {
-                    loader: "file-loader",
-                    options: {
-                        name: "[contenthash].[ext]",
-                    },
-                },
-            ],
+            type: "asset/resource",
+            dependency: { not: ["url"] },
         });
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "webpack-config-builder",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-config-builder",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Simplify webpack config generation",
   "main": "index.js",
   "types": "types.d.ts",


### PR DESCRIPTION
* Switch to a true reusable builder pattern
* Updated `withAssets` and  `withDevServer` to work with webpack >5